### PR TITLE
optimize: add some indent for the headings

### DIFF
--- a/book/plugin.js
+++ b/book/plugin.js
@@ -74,6 +74,7 @@ function buildNavigation(elements) {
     container.setAttribute('data-gumshoe', '');
     navigation.appendChild(container);
 
+    var headingLevel = "h1";
     for (var i = 0; i < elements.length; i++) {
         var text = elements[i].textContent;
         var href = elements[i].querySelector('.anchorjs-link').getAttribute('href');
@@ -82,13 +83,24 @@ function buildNavigation(elements) {
 
         if (i === 0) {
             item.classList.add('selected');
+            headingLevel = elements[i].localName;
         }
 
+        var level = elements[i].localName;
+        var indent = (level.substring(1) - headingLevel.substring(1)) * 16;
+
+        var div = document.createElement('div');
+        div.style.marginLeft = indent + "px";
+
         var anchor = document.createElement('a');
+        
         anchor.text = text;
         anchor.href = href;
 
-        item.appendChild(anchor);
+        div.appendChild(anchor);
+
+        item.appendChild(div);
+
         container.appendChild(item);
     }
 


### PR DESCRIPTION
When create a anchor for the heading of title, create a `<div></div>` and
let the anchor `<a></a>` be the child element of `<div>`.
In the div element, using style 'margin' to control the indent.

I don't know whether this method is good or not, really knows little about Javascript, CSS...

Following is a screenshot:
![image](https://user-images.githubusercontent.com/3725760/66556697-51600080-eb83-11e9-8211-dccbbd161c1e.png)

